### PR TITLE
Adding more set functions

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -301,6 +301,34 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetDayOfYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-01"),
+                {
+                  let original = moment("2018-01-05");
+                  Moment.mutableSetDayOfYear(original, 1);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setDayOfYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-01"),
+                moment("2018-01-05")
+                |> Moment.setDayOfYear(3)
+                |> Moment.setDayOfYear(1)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetMonth",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -413,6 +413,34 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetQuarter",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2013-04-01T00:00:00.000"),
+                {
+                  let original = moment("2013-01-01T00:00:00.000");
+                  Moment.mutableSetQuarter(original, 2);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setQuarter",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2013-04-01T00:00:00.000"),
+                moment("2013-01-01T00:00:00.000")
+                |> Moment.setQuarter(4)
+                |> Moment.setQuarter(2)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetYear",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -77,14 +77,14 @@ let () =
             |> toBe(true)
         );
         test(
-          "#mutableSetDate",
+          "#mutableSetMillisecond",
           () =>
             expect(
               Moment.isSame(
-                moment("2017-01-04"),
+                moment("2017-01-01 02:25:05.100"),
                 {
-                  let original = moment("2017-01-01");
-                  Moment.mutableSetDate(original, 4);
+                  let original = moment("2017-01-01 02:25:05.000");
+                  Moment.mutableSetMillisecond(original, 100);
                   original
                 }
               )
@@ -92,14 +92,70 @@ let () =
             |> toBe(true)
         );
         test(
-          "#setDate",
+          "#setMillisecond",
           () =>
             expect(
               Moment.isSame(
-                moment("2017-01-04"),
-                moment("2017-01-01")
-                |> Moment.setDate(2)
-                |> Moment.setDate(4)
+                moment("2017-01-01 02:25:05.100"),
+                moment("2017-01-01 02:25:05.000")
+                |> Moment.setMillisecond(200)
+                |> Moment.setMillisecond(100)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#mutableSetSecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                {
+                  let original = moment("2017-01-01 02:25:05.100");
+                  Moment.mutableSetSecond(original, 30);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setSecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                moment("2017-01-01 02:25:05.100")
+                |> Moment.setSecond(20)
+                |> Moment.setSecond(30)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#mutableSetMinute",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                {
+                  let original = moment("2017-01-01 02:20:30.100");
+                  Moment.mutableSetMinute(original, 25);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setMinute",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                moment("2017-01-01 02:20:30.100")
+                |> Moment.setMinute(30)
+                |> Moment.setMinute(25)
               )
             )
             |> toBe(true)
@@ -128,6 +184,34 @@ let () =
                 moment("2017-01-01 06:25:05.000")
                 |> Moment.setHour(2)
                 |> Moment.setHour(0)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#mutableSetDate",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-04"),
+                {
+                  let original = moment("2017-01-01");
+                  Moment.mutableSetDate(original, 4);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setDate",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-04"),
+                moment("2017-01-01")
+                |> Moment.setDate(2)
+                |> Moment.setDate(4)
               )
             )
             |> toBe(true)
@@ -184,62 +268,6 @@ let () =
                 moment("2017-01-01")
                 |> Moment.setYear(2018)
                 |> Moment.setYear(2019)
-              )
-            )
-            |> toBe(true)
-        );
-        test(
-          "#mutableSetMillisecond",
-          () =>
-            expect(
-              Moment.isSame(
-                moment("2017-01-01 02:25:05.100"),
-                {
-                  let original = moment("2017-01-01 02:25:05.000");
-                  Moment.mutableSetMillisecond(original, 100);
-                  original
-                }
-              )
-            )
-            |> toBe(true)
-        );
-        test(
-          "#setMillisecond",
-          () =>
-            expect(
-              Moment.isSame(
-                moment("2017-01-01 02:25:05.100"),
-                moment("2017-01-01 02:25:05.000")
-                |> Moment.setMillisecond(200)
-                |> Moment.setMillisecond(100)
-              )
-            )
-            |> toBe(true)
-        );
-        test(
-          "#mutableSetSecond",
-          () =>
-            expect(
-              Moment.isSame(
-                moment("2017-01-01 02:25:30.100"),
-                {
-                  let original = moment("2017-01-01 02:25:05.100");
-                  Moment.mutableSetSecond(original, 30);
-                  original
-                }
-              )
-            )
-            |> toBe(true)
-        );
-        test(
-          "#setSecond",
-          () =>
-            expect(
-              Moment.isSame(
-                moment("2017-01-01 02:25:30.100"),
-                moment("2017-01-01 02:25:05.100")
-                |> Moment.setSecond(20)
-                |> Moment.setSecond(30)
               )
             )
             |> toBe(true)

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -216,6 +216,34 @@ let () =
             )
             |> toBe(true)
         );
+        test(
+          "#mutableSetSecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                {
+                  let original = moment("2017-01-01 02:25:05.100");
+                  Moment.mutableSetSecond(original, 30);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setSecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:30.100"),
+                moment("2017-01-01 02:25:05.100")
+                |> Moment.setSecond(20)
+                |> Moment.setSecond(30)
+              )
+            )
+            |> toBe(true)
+        );
         test("#isValid", () => expect(moment("2017-01-01") |> Moment.isValid) |> toBe(true));
         test("not #isValid", () => expect(moment("") |> Moment.isValid) |> toBe(false));
         test("#isDST", () => expect(moment("2016-01-01T00:00:00") |> Moment.isDST) |> toBe(false));

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -217,6 +217,34 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetDay",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                {
+                  let original = moment("2018-05-05");
+                  Moment.mutableSetDay(original, 2);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setDay",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                moment("2018-05-05")
+                |> Moment.setDay(3)
+                |> Moment.setDay(2)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetMonth",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -245,6 +245,62 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetWeekday",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                {
+                  let original = moment("2018-05-05");
+                  Moment.mutableSetWeekday(original, 2);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setWeekday",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                moment("2018-05-05")
+                |> Moment.setWeekday(3)
+                |> Moment.setWeekday(2)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#mutableSetIsoWeekday",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                {
+                  let original = moment("2018-05-05");
+                  Moment.mutableSetIsoWeekday(original, 2);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setIsoWeekday",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-05-01"),
+                moment("2018-05-05")
+                |> Moment.setIsoWeekday(3)
+                |> Moment.setIsoWeekday(2)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetMonth",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -468,6 +468,62 @@ let () =
             )
             |> toBe(true)
         );
+        test(
+          "#mutableSetWeekYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-05"),
+                {
+                  let original = moment("2019-01-04");
+                  Moment.mutableSetWeekYear(original, 2018);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setWeekYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-05"),
+                moment("2019-01-04")
+                |> Moment.setWeekYear(2020)
+                |> Moment.setWeekYear(2018)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#mutableSetIsoWeekYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-05"),
+                {
+                  let original = moment("2019-01-04");
+                  Moment.mutableSetIsoWeekYear(original, 2018);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setIsoWeekYear",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-05"),
+                moment("2019-01-04")
+                |> Moment.setIsoWeekYear(2020)
+                |> Moment.setIsoWeekYear(2018)
+              )
+            )
+            |> toBe(true)
+        );
         test("#isValid", () => expect(moment("2017-01-01") |> Moment.isValid) |> toBe(true));
         test("not #isValid", () => expect(moment("") |> Moment.isValid) |> toBe(false));
         test("#isDST", () => expect(moment("2016-01-01T00:00:00") |> Moment.isDST) |> toBe(false));

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -357,6 +357,34 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetIsoWeek",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-17"),
+                {
+                  let original = moment("2018-01-03");
+                  Moment.mutableSetIsoWeek(original, 3);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setIsoWeek",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-17"),
+                moment("2018-01-03")
+                |> Moment.setIsoWeek(5)
+                |> Moment.setIsoWeek(3)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetMonth",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -329,6 +329,34 @@ let () =
             |> toBe(true)
         );
         test(
+          "#mutableSetWeek",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-17"),
+                {
+                  let original = moment("2018-01-03");
+                  Moment.mutableSetWeek(original, 3);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setWeek",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2018-01-17"),
+                moment("2018-01-03")
+                |> Moment.setWeek(5)
+                |> Moment.setWeek(3)
+              )
+            )
+            |> toBe(true)
+        );
+        test(
           "#mutableSetMonth",
           () =>
             expect(

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -188,6 +188,34 @@ let () =
             )
             |> toBe(true)
         );
+        test(
+          "#mutableSetMillisecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:05.100"),
+                {
+                  let original = moment("2017-01-01 02:25:05.000");
+                  Moment.mutableSetMillisecond(original, 100);
+                  original
+                }
+              )
+            )
+            |> toBe(true)
+        );
+        test(
+          "#setMillisecond",
+          () =>
+            expect(
+              Moment.isSame(
+                moment("2017-01-01 02:25:05.100"),
+                moment("2017-01-01 02:25:05.000")
+                |> Moment.setMillisecond(200)
+                |> Moment.setMillisecond(100)
+              )
+            )
+            |> toBe(true)
+        );
         test("#isValid", () => expect(moment("2017-01-01") |> Moment.isValid) |> toBe(true));
         test("not #isValid", () => expect(moment("") |> Moment.isValid) |> toBe(false));
         test("#isDST", () => expect(moment("2016-01-01T00:00:00") |> Moment.isDST) |> toBe(false));

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -178,6 +178,12 @@ module Moment = {
     mutableSetMonth(clone, month);
     clone
   };
+  [@bs.send] external mutableSetQuarter : (t, int) => unit = "quarter";
+  let setQuarter = (quarter, moment) => {
+    let clone = clone(moment);
+    mutableSetQuarter(clone, quarter);
+    clone
+  };
   [@bs.send] external mutableSetYear : (t, int) => unit = "year";
   let setYear = (year, moment) => {
     let clone = clone(moment);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -106,16 +106,34 @@ module Moment = {
     mutableEndOf(clone, timeUnit);
     clone
   };
-  [@bs.send] external mutableSetDate : (t, int) => unit = "date";
-  let setDate = (days, moment) => {
+  [@bs.send] external mutableSetMillisecond : (t, int) => unit = "millisecond";
+  let setMillisecond = (milliseconds, moment) => {
     let clone = clone(moment);
-    mutableSetDate(clone, days);
+    mutableSetMillisecond(clone, milliseconds);
+    clone
+  };
+  [@bs.send] external mutableSetSecond : (t, int) => unit = "second";
+  let setSecond = (seconds, moment) => {
+    let clone = clone(moment);
+    mutableSetSecond(clone, seconds);
+    clone
+  };
+  [@bs.send] external mutableSetMinute : (t, int) => unit = "minute";
+  let setMinute = (minutes, moment) => {
+    let clone = clone(moment);
+    mutableSetMinute(clone, minutes);
     clone
   };
   [@bs.send] external mutableSetHour : (t, int) => unit = "hour";
   let setHour = (hours, moment) => {
     let clone = clone(moment);
     mutableSetHour(clone, hours);
+    clone
+  };
+  [@bs.send] external mutableSetDate : (t, int) => unit = "date";
+  let setDate = (days, moment) => {
+    let clone = clone(moment);
+    mutableSetDate(clone, days);
     clone
   };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
@@ -128,18 +146,6 @@ module Moment = {
   let setYear = (years, moment) => {
     let clone = clone(moment);
     mutableSetYear(clone, years);
-    clone
-  };
-  [@bs.send] external mutableSetMillisecond : (t, int) => unit = "millisecond";
-  let setMillisecond = (milliseconds, moment) => {
-    let clone = clone(moment);
-    mutableSetMillisecond(clone, milliseconds);
-    clone
-  };
-  [@bs.send] external mutableSetSecond : (t, int) => unit = "second";
-  let setSecond = (milliseconds, moment) => {
-    let clone = clone(moment);
-    mutableSetSecond(clone, milliseconds);
     clone
   };
   [@bs.send.pipe : t]

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -154,6 +154,12 @@ module Moment = {
     mutableSetIsoWeekday(clone, isoWeekday);
     clone
   };
+  [@bs.send] external mutableSetDayOfYear : (t, int) => unit = "dayOfYear";
+  let setDayOfYear = (dayOfYear, moment) => {
+    let clone = clone(moment);
+    mutableSetDayOfYear(clone, dayOfYear);
+    clone
+  };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
   let setMonth = (month, moment) => {
     let clone = clone(moment);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -190,6 +190,18 @@ module Moment = {
     mutableSetYear(clone, year);
     clone
   };
+  [@bs.send] external mutableSetWeekYear : (t, int) => unit = "weekYear";
+  let setWeekYear = (weekYear, moment) => {
+    let clone = clone(moment);
+    mutableSetWeekYear(clone, weekYear);
+    clone
+  };
+  [@bs.send] external mutableSetIsoWeekYear : (t, int) => unit = "isoWeekYear";
+  let setIsoWeekYear = (isoWeekYear, moment) => {
+    let clone = clone(moment);
+    mutableSetWeekYear(clone, isoWeekYear);
+    clone
+  };
   [@bs.send.pipe : t]
   external get :
     (

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -142,6 +142,18 @@ module Moment = {
     mutableSetDay(clone, day);
     clone
   };
+  [@bs.send] external mutableSetWeekday : (t, int) => unit = "weekday";
+  let setWeekday = (weekday, moment) => {
+    let clone = clone(moment);
+    mutableSetWeekday(clone, weekday);
+    clone
+  };
+  [@bs.send] external mutableSetIsoWeekday : (t, int) => unit = "isoWeekday";
+  let setIsoWeekday = (isoWeekday, moment) => {
+    let clone = clone(moment);
+    mutableSetIsoWeekday(clone, isoWeekday);
+    clone
+  };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
   let setMonth = (month, moment) => {
     let clone = clone(moment);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -160,6 +160,12 @@ module Moment = {
     mutableSetDayOfYear(clone, dayOfYear);
     clone
   };
+  [@bs.send] external mutableSetWeek : (t, int) => unit = "week";
+  let setWeek = (week, moment) => {
+    let clone = clone(moment);
+    mutableSetWeek(clone, week);
+    clone
+  };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
   let setMonth = (month, moment) => {
     let clone = clone(moment);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -166,6 +166,12 @@ module Moment = {
     mutableSetWeek(clone, week);
     clone
   };
+  [@bs.send] external mutableSetIsoWeek : (t, int) => unit = "isoWeek";
+  let setIsoWeek = (isoWeek, moment) => {
+    let clone = clone(moment);
+    mutableSetIsoWeek(clone, isoWeek);
+    clone
+  };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
   let setMonth = (month, moment) => {
     let clone = clone(moment);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -130,6 +130,12 @@ module Moment = {
     mutableSetYear(clone, years);
     clone
   };
+  [@bs.send] external mutableSetMillisecond : (t, int) => unit = "millisecond";
+  let setMillisecond = (milliseconds, moment) => {
+    let clone = clone(moment);
+    mutableSetMillisecond(clone, milliseconds);
+    clone
+  };
   [@bs.send.pipe : t]
   external get :
     (

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -136,6 +136,12 @@ module Moment = {
     mutableSetMillisecond(clone, milliseconds);
     clone
   };
+  [@bs.send] external mutableSetSecond : (t, int) => unit = "second";
+  let setSecond = (milliseconds, moment) => {
+    let clone = clone(moment);
+    mutableSetSecond(clone, milliseconds);
+    clone
+  };
   [@bs.send.pipe : t]
   external get :
     (

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -107,45 +107,51 @@ module Moment = {
     clone
   };
   [@bs.send] external mutableSetMillisecond : (t, int) => unit = "millisecond";
-  let setMillisecond = (milliseconds, moment) => {
+  let setMillisecond = (millisecond, moment) => {
     let clone = clone(moment);
-    mutableSetMillisecond(clone, milliseconds);
+    mutableSetMillisecond(clone, millisecond);
     clone
   };
   [@bs.send] external mutableSetSecond : (t, int) => unit = "second";
-  let setSecond = (seconds, moment) => {
+  let setSecond = (second, moment) => {
     let clone = clone(moment);
-    mutableSetSecond(clone, seconds);
+    mutableSetSecond(clone, second);
     clone
   };
   [@bs.send] external mutableSetMinute : (t, int) => unit = "minute";
-  let setMinute = (minutes, moment) => {
+  let setMinute = (minute, moment) => {
     let clone = clone(moment);
-    mutableSetMinute(clone, minutes);
+    mutableSetMinute(clone, minute);
     clone
   };
   [@bs.send] external mutableSetHour : (t, int) => unit = "hour";
-  let setHour = (hours, moment) => {
+  let setHour = (hour, moment) => {
     let clone = clone(moment);
-    mutableSetHour(clone, hours);
+    mutableSetHour(clone, hour);
     clone
   };
   [@bs.send] external mutableSetDate : (t, int) => unit = "date";
-  let setDate = (days, moment) => {
+  let setDate = (date, moment) => {
     let clone = clone(moment);
-    mutableSetDate(clone, days);
+    mutableSetDate(clone, date);
+    clone
+  };
+  [@bs.send] external mutableSetDay : (t, int) => unit = "day";
+  let setDay = (day, moment) => {
+    let clone = clone(moment);
+    mutableSetDay(clone, day);
     clone
   };
   [@bs.send] external mutableSetMonth : (t, int) => unit = "month";
-  let setMonth = (months, moment) => {
+  let setMonth = (month, moment) => {
     let clone = clone(moment);
-    mutableSetMonth(clone, months);
+    mutableSetMonth(clone, month);
     clone
   };
   [@bs.send] external mutableSetYear : (t, int) => unit = "year";
-  let setYear = (years, moment) => {
+  let setYear = (year, moment) => {
     let clone = clone(moment);
-    mutableSetYear(clone, years);
+    mutableSetYear(clone, year);
     clone
   };
   [@bs.send.pipe : t]


### PR DESCRIPTION
Added the following functions along with tests:

1. `mutableSetMillisecond`
1. `setMillisecond`
1. `mutableSetSecond`
1. `setSecond`
1. `mutableSetMinute`
1. `setMinute`
1. `mutableSetDay`
1. `setDay`
1. `mutableSetWeekday`
1. `setWeekday`
1. `mutableSetIsoWeekday`
1. `setIsoWeekday`
1. `mutableSetWeek`
1. `setWeek`
1. `mutableSetIsoWeek`
1. `setIsoWeek`
1. `mutableSetMonth`
1. `setMonth`
1. `mutableSetQuarter`
1. `setQuarter`
1. `mutableSetYear`
1. `setYear`
1. `mutableSetWeekYear`
1. `setWeekYear`
1. `mutableSetIsoWeekYear`
1. `setIsoWeekYear`